### PR TITLE
Address issues #1 #2 #3

### DIFF
--- a/src/generate-podcast.py
+++ b/src/generate-podcast.py
@@ -1,5 +1,6 @@
 import os
 import requests
+import re
 from dotenv import load_dotenv
 
 # Load environment variables from .env file
@@ -69,15 +70,26 @@ async def generate_voice(text, index):
 # Main function
 
 async def main():
-    # Open text file and split into sentences
-    with open('./data/test_data.txt', 'r') as file:
-        text_array = file.read().split(".")
+    # Open text file with UTF-8 encoding
+    with open('./data/test_data.txt', 'r', encoding='utf-8') as file:
+        # Use regular expression to keep periods with sentences
+        text_array = re.split(r'(?<=\.)\s+', file.read().strip())
 
-        # Iterate sentences and generate audio for each
-        for index, text in enumerate(text_array):
-            await generate_voice(text, index)
-            print(text)
+        # Check if there is an uneven number of sentences
+        if len(text_array) % 2 != 0:
+            # Add an empty string to make it even
+            text_array.append("")
+
+        sentences_to_process = list(zip(text_array[0::2], text_array[1::2]))
+
+        # Iterate sentence pairs and generate audio for each pair
+        for index, (first_sentence, second_sentence) in enumerate(sentences_to_process):
+            combined_sentence = first_sentence
+            combined_sentence += ' ' + second_sentence if second_sentence else ''
+            await generate_voice(combined_sentence, index)
+            print(combined_sentence)
     print("Finished generation! Don't forget to run python ./src/merge-podcast.py to combine all audio files 🤠")
+
 
 if __name__ == "__main__":
     import asyncio

--- a/src/merge-podcast.py
+++ b/src/merge-podcast.py
@@ -1,20 +1,25 @@
-from pydub import AudioSegment
 import os
+import subprocess
 
-# Get all audio files from the chunks folder
-audio_files = os.listdir(os.path.join(
-    os.path.dirname(__name__), "output/chunks/"))
+# Directory containing the MP3 files
+directory = './output/chunks/'
 
-# Initialize combined audio file
-combined = AudioSegment.empty()
+# Check if filelist.txt exists and clear it
+filelist_path = os.path.join(directory, 'filelist.txt')
+if os.path.exists(filelist_path):
+    os.remove(filelist_path)
 
-# Combine all audio files
-for file in audio_files:
-    if file.endswith(".mp3"):
-        sound = AudioSegment.from_mp3(os.path.join(
-            os.path.dirname(__name__), "output/chunks/"+file))
-        combined = combined + sound
+# Fetch all mp3 files and sort them numerically
+files = [f for f in os.listdir(directory) if f.endswith('.mp3')]
+files.sort(key=lambda f: int(''.join(filter(str.isdigit, f))))
 
-# Export combined audio file
-combined.export(os.path.join(
-    os.path.dirname(__name__), "output/output.mp3"), format="mp3")
+# Write the sorted file names to filelist.txt
+with open(filelist_path, 'w') as file:
+    for f in files:
+        file.write(f"file '{f}'\n")
+
+# Run FFmpeg command
+output_file = os.path.join('./output/', 'output.mp3')
+ffmpeg_command = f'ffmpeg -f concat -safe 0 -i "{filelist_path}" -c copy "{output_file}"'
+subprocess.run(ffmpeg_command)
+


### PR DESCRIPTION
Use python to generate a filelist with the correct file order for generations with over 100 chunks.

Replace AudioSegment with direct call to ffmpeg using copy to prevent re-encoding and preserve quality. Direct ffmpeg is rediculously fast in comparison.

Use regular expressions to speed up chunking and do so without stripping punctuation.

Send two chunks per api request to alleviate stacatto generations on short sentences.


This commit fixes #1 and #2 #3